### PR TITLE
Bootstrap release-please at 3.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "packages": {
-    ".": {}
+    ".": {
+      "release-as": "3.0.1"
+    }
   }
 }


### PR DESCRIPTION
Fixes the release PR (#4) proposing 1.0.0 instead of matching the existing v3 baseline. See commit message for why the manifest alone wasn't enough.