### PR TITLE
Remove old manual scratch script with hardcoded token, gitignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.env

--- a/test/package.json
+++ b/test/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "@octokit/rest": "^20.1.0"
-  }
-}


### PR DESCRIPTION
## Summary
- Deletes test/script.js and its unused package.json/package-lock.json - a manual, non-assertion smoke-test script that hit the live GitHub API directly and hardcoded a real-looking PAT. test/index.test.js's Jest suite already covers this with mocked, repeatable tests.
- Adds .env to .gitignore (wasn't previously excluded).

## Note
The PAT that was hardcoded in test/script.js should still be revoked on GitHub if it hasn't been already - it's now removed from the repo, but this doesn't invalidate anything that may have already been shared/committed to history elsewhere.