### PR TITLE
Run release-please in manifest mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,4 @@ jobs:
       - name: Run Release Please
         uses: googleapis/release-please-action@v4
         with:
-          release-type: simple
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Passing `release-type: simple` as an action input forces non-manifest mode, which ignores release-please-config.json (and release-as) entirely - confirmed via release-please-action's docs. That's the actual root cause of PR #4 proposing 1.0.0 instead of 3.0.1 even after #5 merged. Dropping the input lets manifest mode (the default) read the config file.