### PR TITLE
Add page-size input for repos with many checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ jobs:
 | `github-token`  | Token that is used to interact with GitHub   | ✅        |                                                  |
 | `check-names`   | Comma-separated list of check names to rerun | ✅        |                                                  |
 | `target-branch` | Branch for which checks should be rerun      | ❌        | the head ref of the pull request, default branch |
+| `page-size`     | Check runs to fetch per page from the GitHub API | ❌    | 30 (GitHub API default)                          |
 ## Permissions
 
 Depending on the permissions granted to your token, you may lack some rights.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ inputs:
       If not provided, the branch of the pull request that triggered
       the workflow is used
     required: false
+  page-size:
+    description: |
+      Number of check runs to fetch per page from the GitHub API (default 30).
+      Increase this if your target branch has more checks than the default
+      page size, otherwise checks beyond the first page won't be found.
+    required: false
 
 runs:
   using: 'node20'

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const github = require('@actions/github');
 async function run() {
   try {
     const checkNames = core.getInput('check-names').split(', ');
+    const pageSize = core.getInput('page-size') || undefined;
     const { owner, repo } = github.context.repo;
     const token = core.getInput('github-token');
     const octokit = github.getOctokit(token);
@@ -11,7 +12,7 @@ async function run() {
 
     core.info(`Branch: ${branch}`);
 
-    const checksResult = await octokit.rest.checks.listForRef({ owner, repo, ref: branch });
+    const checksResult = await octokit.rest.checks.listForRef({ owner, repo, ref: branch, per_page: pageSize });
 
     for (const checkName of checkNames) {
       const checkRun = checksResult.data.check_runs.find(check_run => check_run.name === checkName.trim());
@@ -21,11 +22,11 @@ async function run() {
 
         try {
           await octokit.rest.actions.reRunJobForWorkflowRun({ owner, repo, job_id: jobId });
-          await waitUntilScheduled(octokit, owner, repo, branch, checkName.trim(), checkRun.id);
+          await waitUntilScheduled(octokit, owner, repo, branch, checkName.trim(), checkRun.id, { pageSize });
           core.info(`"${checkName}" job has been triggered again.`);
 
         } catch (error) {
-          if (error.message.includes('This workflow is already running')) {
+          if (error.message.includes('is already running')) {
             core.warning(`"${checkName}" job is already running.`);
           } else {
             throw error;
@@ -40,11 +41,11 @@ async function run() {
   }
 }
 
-async function waitUntilScheduled(octokit, owner, repo, ref, checkName, previousCheckRunId, { timeoutMs = 30000, intervalMs = 2000 } = {}) {
+async function waitUntilScheduled(octokit, owner, repo, ref, checkName, previousCheckRunId, { timeoutMs = 30000, intervalMs = 2000, pageSize } = {}) {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const checksResult = await octokit.rest.checks.listForRef({ owner, repo, ref });
+    const checksResult = await octokit.rest.checks.listForRef({ owner, repo, ref, per_page: pageSize });
     const checkRun = checksResult.data.check_runs.find(check_run => check_run.name === checkName);
 
     // A rerun either creates a new check run (different id) or resets the

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -117,6 +117,25 @@ describe('run', () => {
     expect(mockCore.setFailed).not.toHaveBeenCalled();
   });
 
+  it('forwards page-size as per_page to the checks API', async () => {
+    mockCore.getInput.mockImplementation(name => {
+      if (name === 'check-names') return 'build';
+      if (name === 'page-size') return '100';
+      return '';
+    });
+    mockOctokit.rest.checks.listForRef
+      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 1, name: 'build' })] } })
+      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 2, name: 'build' })] } });
+    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockResolvedValue({});
+    mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
+
+    await run();
+
+    expect(mockOctokit.rest.checks.listForRef).toHaveBeenCalledWith(
+      expect.objectContaining({ per_page: '100' })
+    );
+  });
+
   it('logs when the check is not found', async () => {
     mockOctokit.rest.checks.listForRef.mockResolvedValue({ data: { check_runs: [] } });
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };


### PR DESCRIPTION
## Summary
Re-implements #1's idea (credit @BakerNet) against current master, since that PR is now 21 months stale and conflicting with the recent rerun-scheduling rewrite.

- Adds a `page-size` input, forwarded as `per_page` to `checks.listForRef` - the GitHub API defaults to 30 results per page, so repos with more checks than that could silently miss a match.
- Also applied `page-size` to the `waitUntilScheduled` polling call, for consistency.
- Loosens the "already running" error match from `'This workflow is already running'` to `'is already running'`, since the exact GitHub error text can vary (also from #1).
- Updated `action.yml`/README docs and added a unit test confirming `page-size` is forwarded as `per_page`.

Closes #1 (superseding it with a rebased equivalent).

## Test plan
- [x] `pnpm test` passes locally (12 tests)