### PR TITLE
Paginate through all checks, add outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,16 @@ jobs:
 | `github-token`  | Token that is used to interact with GitHub   | ✅        |                                                  |
 | `check-names`   | Comma-separated list of check names to rerun | ✅        |                                                  |
 | `target-branch` | Branch for which checks should be rerun      | ❌        | the head ref of the pull request, default branch |
-| `page-size`     | Check runs to fetch per page from the GitHub API | ❌    | 30 (GitHub API default)                          |
+| `page-size`     | Check runs to fetch per page while paginating through the GitHub API (all pages are always fetched) | ❌ | 30 (GitHub API default) |
+
+### Action outputs
+
+| Name                     | Description                                            |
+|--------------------------|---------------------------------------------------------|
+| `rerun-checks`           | Comma-separated list of check names that were successfully rerun |
+| `not-found-checks`       | Comma-separated list of check names that were not found |
+| `already-running-checks` | Comma-separated list of check names that were already running |
+
 ## Permissions
 
 Depending on the permissions granted to your token, you may lack some rights.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,14 @@ inputs:
     description: 'GitHub API per_page option'
     required: false
 
+outputs:
+  rerun-checks:
+    description: 'Comma-separated list of check names that were successfully rerun'
+  not-found-checks:
+    description: 'Comma-separated list of check names that were not found'
+  already-running-checks:
+    description: 'Comma-separated list of check names that were already running'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,14 @@ async function run() {
 
     core.info(`Branch: ${branch}`);
 
-    const checksResult = await octokit.rest.checks.listForRef({ owner, repo, ref: branch, per_page: pageSize });
+    const checkRuns = await octokit.paginate(octokit.rest.checks.listForRef, { owner, repo, ref: branch, per_page: pageSize });
+
+    const rerunChecks = [];
+    const notFoundChecks = [];
+    const alreadyRunningChecks = [];
 
     for (const checkName of checkNames) {
-      const checkRun = checksResult.data.check_runs.find(check_run => check_run.name === checkName);
+      const checkRun = checkRuns.find(check_run => check_run.name === checkName);
 
       if (checkRun) {
         const jobId = checkRun.details_url.split('/').slice(-1)[0];
@@ -24,18 +28,25 @@ async function run() {
           await octokit.rest.actions.reRunJobForWorkflowRun({ owner, repo, job_id: jobId });
           await waitUntilScheduled(octokit, owner, repo, branch, checkName, checkRun.id, { pageSize });
           core.info(`"${checkName}" job has been triggered again.`);
+          rerunChecks.push(checkName);
 
         } catch (error) {
           if (error.message.includes('is already running')) {
             core.warning(`"${checkName}" job is already running.`);
+            alreadyRunningChecks.push(checkName);
           } else {
             throw error;
           }
         }
       } else {
         core.info(`"${checkName}" check not found.`);
+        notFoundChecks.push(checkName);
       }
     }
+
+    core.setOutput('rerun-checks', rerunChecks.join(', '));
+    core.setOutput('not-found-checks', notFoundChecks.join(', '));
+    core.setOutput('already-running-checks', alreadyRunningChecks.join(', '));
   } catch (error) {
     core.setFailed(error.message);
   }
@@ -45,8 +56,8 @@ async function waitUntilScheduled(octokit, owner, repo, ref, checkName, previous
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const checksResult = await octokit.rest.checks.listForRef({ owner, repo, ref, per_page: pageSize });
-    const checkRun = checksResult.data.check_runs.find(check_run => check_run.name === checkName);
+    const checkRuns = await octokit.paginate(octokit.rest.checks.listForRef, { owner, repo, ref, per_page: pageSize });
+    const checkRun = checkRuns.find(check_run => check_run.name === checkName);
 
     // A rerun either creates a new check run (different id) or resets the
     // existing one to queued/in_progress - either signals it was scheduled.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,7 @@ const mockCore = {
   info: jest.fn(),
   warning: jest.fn(),
   setFailed: jest.fn(),
+  setOutput: jest.fn(),
 };
 
 const mockOctokit = {
@@ -11,6 +12,7 @@ const mockOctokit = {
     actions: { reRunJobForWorkflowRun: jest.fn() },
     repos: { get: jest.fn() },
   },
+  paginate: jest.fn(),
 };
 
 const mockGithub = {
@@ -66,9 +68,7 @@ describe('waitUntilScheduled', () => {
   const opts = { timeoutMs: 20, intervalMs: 1 };
 
   it('resolves once a check run with a new id appears', async () => {
-    mockOctokit.rest.checks.listForRef.mockResolvedValue({
-      data: { check_runs: [checkRun({ id: 2, name: 'build' })] },
-    });
+    mockOctokit.paginate.mockResolvedValue([checkRun({ id: 2, name: 'build' })]);
 
     await waitUntilScheduled(mockOctokit, 'owner', 'repo', 'main', 'build', 1, opts);
 
@@ -76,9 +76,7 @@ describe('waitUntilScheduled', () => {
   });
 
   it('resolves once the same check run flips to queued', async () => {
-    mockOctokit.rest.checks.listForRef.mockResolvedValue({
-      data: { check_runs: [checkRun({ id: 1, name: 'build', status: 'queued' })] },
-    });
+    mockOctokit.paginate.mockResolvedValue([checkRun({ id: 1, name: 'build', status: 'queued' })]);
 
     await waitUntilScheduled(mockOctokit, 'owner', 'repo', 'main', 'build', 1, opts);
 
@@ -86,9 +84,7 @@ describe('waitUntilScheduled', () => {
   });
 
   it('warns on timeout when nothing changes', async () => {
-    mockOctokit.rest.checks.listForRef.mockResolvedValue({
-      data: { check_runs: [checkRun({ id: 1, name: 'build', status: 'completed' })] },
-    });
+    mockOctokit.paginate.mockResolvedValue([checkRun({ id: 1, name: 'build', status: 'completed' })]);
 
     await waitUntilScheduled(mockOctokit, 'owner', 'repo', 'main', 'build', 1, opts);
 
@@ -102,9 +98,9 @@ describe('run', () => {
   });
 
   it('reruns a matching check and confirms it was scheduled', async () => {
-    mockOctokit.rest.checks.listForRef
-      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 1, name: 'build' })] } })
-      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 2, name: 'build' })] } });
+    mockOctokit.paginate
+      .mockResolvedValueOnce([checkRun({ id: 1, name: 'build' })])
+      .mockResolvedValueOnce([checkRun({ id: 2, name: 'build' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockResolvedValue({});
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 
@@ -114,17 +110,18 @@ describe('run', () => {
       owner: 'owner', repo: 'repo', job_id: '111',
     });
     expect(mockCore.info).toHaveBeenCalledWith('"build" job has been triggered again.');
+    expect(mockCore.setOutput).toHaveBeenCalledWith('rerun-checks', 'build');
+    expect(mockCore.setOutput).toHaveBeenCalledWith('not-found-checks', '');
+    expect(mockCore.setOutput).toHaveBeenCalledWith('already-running-checks', '');
     expect(mockCore.setFailed).not.toHaveBeenCalled();
   });
 
   it('reruns multiple checks separated without a space after the comma', async () => {
     mockCore.getInput.mockImplementation(name => (name === 'check-names' ? 'build,test' : ''));
-    mockOctokit.rest.checks.listForRef
-      .mockResolvedValueOnce({
-        data: { check_runs: [checkRun({ id: 1, name: 'build' }), checkRun({ id: 2, name: 'test', jobId: '222' })] },
-      })
-      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 11, name: 'build' })] } })
-      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 22, name: 'test', jobId: '222' })] } });
+    mockOctokit.paginate
+      .mockResolvedValueOnce([checkRun({ id: 1, name: 'build' }), checkRun({ id: 2, name: 'test', jobId: '222' })])
+      .mockResolvedValueOnce([checkRun({ id: 11, name: 'build' })])
+      .mockResolvedValueOnce([checkRun({ id: 22, name: 'test', jobId: '222' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockResolvedValue({});
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 
@@ -138,39 +135,39 @@ describe('run', () => {
     });
   });
 
-  it('forwards page-size as per_page to the checks API', async () => {
+  it('paginates through all pages when forwarding page-size', async () => {
     mockCore.getInput.mockImplementation(name => {
       if (name === 'check-names') return 'build';
       if (name === 'page-size') return '100';
       return '';
     });
-    mockOctokit.rest.checks.listForRef
-      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 1, name: 'build' })] } })
-      .mockResolvedValueOnce({ data: { check_runs: [checkRun({ id: 2, name: 'build' })] } });
+    mockOctokit.paginate
+      .mockResolvedValueOnce([checkRun({ id: 1, name: 'build' })])
+      .mockResolvedValueOnce([checkRun({ id: 2, name: 'build' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockResolvedValue({});
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 
     await run();
 
-    expect(mockOctokit.rest.checks.listForRef).toHaveBeenCalledWith(
+    expect(mockOctokit.paginate).toHaveBeenCalledWith(
+      mockOctokit.rest.checks.listForRef,
       expect.objectContaining({ per_page: '100' })
     );
   });
 
   it('logs when the check is not found', async () => {
-    mockOctokit.rest.checks.listForRef.mockResolvedValue({ data: { check_runs: [] } });
+    mockOctokit.paginate.mockResolvedValue([]);
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 
     await run();
 
     expect(mockCore.info).toHaveBeenCalledWith('"build" check not found.');
     expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).not.toHaveBeenCalled();
+    expect(mockCore.setOutput).toHaveBeenCalledWith('not-found-checks', 'build');
   });
 
   it('warns instead of failing when the job is already running', async () => {
-    mockOctokit.rest.checks.listForRef.mockResolvedValue({
-      data: { check_runs: [checkRun({ id: 1, name: 'build' })] },
-    });
+    mockOctokit.paginate.mockResolvedValue([checkRun({ id: 1, name: 'build' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(
       new Error('This workflow is already running')
     );
@@ -179,13 +176,12 @@ describe('run', () => {
     await run();
 
     expect(mockCore.warning).toHaveBeenCalledWith('"build" job is already running.');
+    expect(mockCore.setOutput).toHaveBeenCalledWith('already-running-checks', 'build');
     expect(mockCore.setFailed).not.toHaveBeenCalled();
   });
 
   it('fails the action on unexpected errors', async () => {
-    mockOctokit.rest.checks.listForRef.mockResolvedValue({
-      data: { check_runs: [checkRun({ id: 1, name: 'build' })] },
-    });
+    mockOctokit.paginate.mockResolvedValue([checkRun({ id: 1, name: 'build' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(new Error('boom'));
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 


### PR DESCRIPTION
## Summary
- Switches from a single `checks.listForRef` call to `octokit.paginate()`, so all check runs are fetched regardless of how many pages that takes. `page-size` alone (added in #1) only capped the *first* page size - a repo with more checks than that would still silently miss matches beyond it.
- Adds outputs: `rerun-checks`, `not-found-checks`, `already-running-checks` (comma-separated), so downstream steps can consume what happened instead of only reading logs.
- Updated action.yml/README docs and test suite (mocks `octokit.paginate` now instead of the raw `listForRef` response shape).

## Test plan
- [x] `pnpm test` passes locally (13 tests)