### PR TITLE
Retry rerun calls, rerun-all-failed mode, fix matrix duplicate handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 | Name            | Description                                  | Required | Default                                          |
 |-----------------|----------------------------------------------|----------|--------------------------------------------------|
 | `github-token`  | Token that is used to interact with GitHub   | ✅        |                                                  |
-| `check-names`   | Comma-separated list of check names to rerun | ✅        |                                                  |
+| `check-names`   | Comma-separated list of check names to rerun, or `*` to rerun every failed check | ✅ |                            |
 | `target-branch` | Branch for which checks should be rerun      | ❌        | the head ref of the pull request, default branch |
 | `page-size`     | Check runs to fetch per page while paginating through the GitHub API (all pages are always fetched) | ❌ | 30 (GitHub API default) |
 
@@ -54,7 +54,8 @@ To run successfully, this actions at least requires the following permissions:
 
 ```yaml
 permissions:
-  pull-requests: write 
+  pull-requests: write
+  actions: write
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,10 @@ description: 'Rerun specified GitHub checks'
 
 inputs:
   check-names:
-    description: 'Array of check names to rerun'
+    description: |
+      Comma-separated list of check names to rerun.
+      Pass '*' to rerun every check with a 'failure' conclusion instead
+      of naming each one.
     required: true
   github-token:
     description: 'GitHub token'

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "author": "Khaled AbuShqear",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/thollander/actions-comment-pull-request/issues"
+    "url": "https://github.com/shqear93/rerun-checks/issues"
   },
-  "homepage": "https://github.com/thollander/actions-comment-pull-request#readme",
+  "homepage": "https://github.com/shqear93/rerun-checks#readme",
   "dependencies": {
-    "@actions/core": "^1.10.1",
-    "@actions/github": "^5.0.3"
+    "@actions/core": "^2.0.3",
+    "@actions/github": "^8.0.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@actions/core':
-        specifier: ^1.10.1
-        version: 1.10.1
+        specifier: ^2.0.3
+        version: 2.0.3
       '@actions/github':
-        specifier: ^5.0.3
-        version: 5.1.1
+        specifier: ^8.0.1
+        version: 8.0.1
     devDependencies:
       '@vercel/ncc':
         specifier: ^0.38.1
@@ -24,14 +24,20 @@ importers:
 
 packages:
 
-  '@actions/core@1.10.1':
-    resolution: {integrity: sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==}
+  '@actions/core@2.0.3':
+    resolution: {integrity: sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==}
 
-  '@actions/github@5.1.1':
-    resolution: {integrity: sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==}
+  '@actions/exec@2.0.0':
+    resolution: {integrity: sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==}
 
-  '@actions/http-client@2.2.1':
-    resolution: {integrity: sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==}
+  '@actions/github@8.0.1':
+    resolution: {integrity: sha512-cue7mS+kx1/2Dnc/094pitRUm+0uPXVXYVaqOdZwD15BsXATWYHW3idJDYOlyBc5gJlzAQ/w5YLU4LR8D7hjVg==}
+
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
+
+  '@actions/io@2.0.0':
+    resolution: {integrity: sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -198,10 +204,6 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -292,39 +294,47 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@octokit/auth-token@2.5.0':
-    resolution: {integrity: sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==}
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
 
-  '@octokit/core@3.6.0':
-    resolution: {integrity: sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==}
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
 
-  '@octokit/endpoint@6.0.12':
-    resolution: {integrity: sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
 
-  '@octokit/graphql@4.8.0':
-    resolution: {integrity: sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==}
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
 
-  '@octokit/openapi-types@12.11.0':
-    resolution: {integrity: sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==}
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
-  '@octokit/plugin-paginate-rest@2.21.3':
-    resolution: {integrity: sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==}
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '>=2'
+      '@octokit/core': '>=6'
 
-  '@octokit/plugin-rest-endpoint-methods@5.16.2':
-    resolution: {integrity: sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==}
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '>=3'
+      '@octokit/core': '>=6'
 
-  '@octokit/request-error@2.1.0':
-    resolution: {integrity: sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==}
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
 
-  '@octokit/request@5.6.3':
-    resolution: {integrity: sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==}
+  '@octokit/request@10.0.11':
+    resolution: {integrity: sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==}
+    engines: {node: '>= 20'}
 
-  '@octokit/types@6.41.0':
-    resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -431,8 +441,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  before-after-hook@2.2.3:
-    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
@@ -503,6 +513,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -535,9 +549,6 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-
-  deprecation@2.3.1:
-    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -686,10 +697,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -866,6 +873,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -915,15 +925,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -1120,9 +1121,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
@@ -1138,12 +1136,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@5.28.4:
-    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
-    engines: {node: '>=14.0'}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
 
-  universal-user-agent@6.0.1:
-    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1151,23 +1149,12 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1206,24 +1193,31 @@ packages:
 
 snapshots:
 
-  '@actions/core@1.10.1':
+  '@actions/core@2.0.3':
     dependencies:
-      '@actions/http-client': 2.2.1
-      uuid: 8.3.2
+      '@actions/exec': 2.0.0
+      '@actions/http-client': 3.0.2
 
-  '@actions/github@5.1.1':
+  '@actions/exec@2.0.0':
     dependencies:
-      '@actions/http-client': 2.2.1
-      '@octokit/core': 3.6.0
-      '@octokit/plugin-paginate-rest': 2.21.3(@octokit/core@3.6.0)
-      '@octokit/plugin-rest-endpoint-methods': 5.16.2(@octokit/core@3.6.0)
-    transitivePeerDependencies:
-      - encoding
+      '@actions/io': 2.0.0
 
-  '@actions/http-client@2.2.1':
+  '@actions/github@8.0.1':
+    dependencies:
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      undici: 6.27.0
+
+  '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 5.28.4
+      undici: 6.27.0
+
+  '@actions/io@2.0.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -1413,8 +1407,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
-
-  '@fastify/busboy@2.1.1': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -1607,69 +1599,57 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@octokit/auth-token@2.5.0':
-    dependencies:
-      '@octokit/types': 6.41.0
+  '@octokit/auth-token@6.0.0': {}
 
-  '@octokit/core@3.6.0':
+  '@octokit/core@7.0.6':
     dependencies:
-      '@octokit/auth-token': 2.5.0
-      '@octokit/graphql': 4.8.0
-      '@octokit/request': 5.6.3
-      '@octokit/request-error': 2.1.0
-      '@octokit/types': 6.41.0
-      before-after-hook: 2.2.3
-      universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@6.0.12':
+  '@octokit/endpoint@11.0.3':
     dependencies:
-      '@octokit/types': 6.41.0
-      is-plain-object: 5.0.0
-      universal-user-agent: 6.0.1
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/graphql@4.8.0':
+  '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 5.6.3
-      '@octokit/types': 6.41.0
-      universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/request': 10.0.11
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
-  '@octokit/openapi-types@12.11.0': {}
+  '@octokit/openapi-types@27.0.0': {}
 
-  '@octokit/plugin-paginate-rest@2.21.3(@octokit/core@3.6.0)':
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 3.6.0
-      '@octokit/types': 6.41.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/plugin-rest-endpoint-methods@5.16.2(@octokit/core@3.6.0)':
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 3.6.0
-      '@octokit/types': 6.41.0
-      deprecation: 2.3.1
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/request-error@2.1.0':
+  '@octokit/request-error@7.1.0':
     dependencies:
-      '@octokit/types': 6.41.0
-      deprecation: 2.3.1
-      once: 1.4.0
+      '@octokit/types': 16.0.0
 
-  '@octokit/request@5.6.3':
+  '@octokit/request@10.0.11':
     dependencies:
-      '@octokit/endpoint': 6.0.12
-      '@octokit/request-error': 2.1.0
-      '@octokit/types': 6.41.0
-      is-plain-object: 5.0.0
-      node-fetch: 2.7.0
-      universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
 
-  '@octokit/types@6.41.0':
+  '@octokit/types@16.0.0':
     dependencies:
-      '@octokit/openapi-types': 12.11.0
+      '@octokit/openapi-types': 27.0.0
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -1810,7 +1790,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.43: {}
 
-  before-after-hook@2.2.3: {}
+  before-after-hook@4.0.0: {}
 
   brace-expansion@1.1.16:
     dependencies:
@@ -1872,6 +1852,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   create-jest@29.7.0(@types/node@26.1.1):
@@ -1902,8 +1884,6 @@ snapshots:
   dedent@1.7.2: {}
 
   deepmerge@4.3.1: {}
-
-  deprecation@2.3.1: {}
 
   detect-newline@3.1.0: {}
 
@@ -2025,8 +2005,6 @@ snapshots:
   is-generator-fn@2.1.0: {}
 
   is-number@7.0.0: {}
-
-  is-plain-object@5.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -2392,6 +2370,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-with-bigint@3.5.10: {}
+
   json5@2.2.3: {}
 
   kleur@3.0.3: {}
@@ -2432,10 +2412,6 @@ snapshots:
   ms@2.1.3: {}
 
   natural-compare@1.4.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-int64@0.4.0: {}
 
@@ -2598,8 +2574,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tr46@0.0.3: {}
-
   tunnel@0.0.6: {}
 
   type-detect@4.0.8: {}
@@ -2608,19 +2582,15 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@5.28.4:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.27.0: {}
 
-  universal-user-agent@6.0.1: {}
+  universal-user-agent@7.0.3: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
       browserslist: 4.28.6
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  uuid@8.3.2: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -2631,13 +2601,6 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ const github = require('@actions/github');
 
 async function run() {
   try {
-    const checkNames = core.getInput('check-names').split(',').map(name => name.trim());
+    const checkNamesInput = core.getInput('check-names').trim();
+    const rerunAllFailed = checkNamesInput === '*';
     const pageSize = core.getInput('page-size') || undefined;
     const { owner, repo } = github.context.repo;
     const token = core.getInput('github-token');
@@ -14,18 +15,26 @@ async function run() {
 
     const checkRuns = await octokit.paginate(octokit.rest.checks.listForRef, { owner, repo, ref: branch, per_page: pageSize });
 
+    // { name, checkRun } pairs to act on - checkRun is null when a named
+    // check wasn't found. In rerun-all-failed mode there's nothing to
+    // "not find", so every entry always has a checkRun.
+    const targets = rerunAllFailed
+      ? checkRuns.filter(checkRun => checkRun.conclusion === 'failure').map(checkRun => ({ name: checkRun.name, checkRun }))
+      : checkNamesInput.split(',').map(name => name.trim()).flatMap(name => {
+          const matches = checkRuns.filter(checkRun => checkRun.name === name);
+          return matches.length > 0 ? matches.map(checkRun => ({ name, checkRun })) : [{ name, checkRun: null }];
+        });
+
     const rerunChecks = [];
     const notFoundChecks = [];
     const alreadyRunningChecks = [];
 
-    for (const checkName of checkNames) {
-      const checkRun = checkRuns.find(check_run => check_run.name === checkName);
-
+    for (const { name: checkName, checkRun } of targets) {
       if (checkRun) {
         const jobId = checkRun.details_url.split('/').slice(-1)[0];
 
         try {
-          await octokit.rest.actions.reRunJobForWorkflowRun({ owner, repo, job_id: jobId });
+          await reRunJob(octokit, owner, repo, jobId);
           await waitUntilScheduled(octokit, owner, repo, branch, checkName, checkRun.id, { pageSize });
           core.info(`"${checkName}" job has been triggered again.`);
           rerunChecks.push(checkName);
@@ -44,6 +53,10 @@ async function run() {
       }
     }
 
+    if (rerunAllFailed && targets.length === 0) {
+      core.info('No failed checks found to rerun.');
+    }
+
     core.setOutput('rerun-checks', rerunChecks.join(', '));
     core.setOutput('not-found-checks', notFoundChecks.join(', '));
     core.setOutput('already-running-checks', alreadyRunningChecks.join(', '));
@@ -52,16 +65,33 @@ async function run() {
   }
 }
 
+async function reRunJob(octokit, owner, repo, jobId, { retries = 3, baseDelayMs = 1000 } = {}) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await octokit.rest.actions.reRunJobForWorkflowRun({ owner, repo, job_id: jobId });
+      return;
+    } catch (error) {
+      // Not a transient failure - the caller handles this case specially.
+      if (error.message.includes('is already running') || attempt > retries) {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, baseDelayMs * 2 ** (attempt - 1)));
+    }
+  }
+}
+
 async function waitUntilScheduled(octokit, owner, repo, ref, checkName, previousCheckRunId, { timeoutMs = 30000, intervalMs = 2000, pageSize } = {}) {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
     const checkRuns = await octokit.paginate(octokit.rest.checks.listForRef, { owner, repo, ref, per_page: pageSize });
-    const checkRun = checkRuns.find(check_run => check_run.name === checkName);
+    const checkRun = checkRuns.find(check_run => check_run.id === previousCheckRunId);
 
-    // A rerun either creates a new check run (different id) or resets the
-    // existing one to queued/in_progress - either signals it was scheduled.
-    if (checkRun && (checkRun.id !== previousCheckRunId || checkRun.status === 'queued' || checkRun.status === 'in_progress')) {
+    // Matched by id, not name, since duplicate names (e.g. matrix jobs) would
+    // otherwise make a name-only lookup match the wrong instance. A rerun
+    // either replaces this id with a new attempt (id disappears) or resets
+    // this same check run to queued/in_progress - either signals scheduled.
+    if (!checkRun || checkRun.status === 'queued' || checkRun.status === 'in_progress') {
       return;
     }
 
@@ -87,4 +117,4 @@ if (require.main === module) {
   run();
 }
 
-module.exports = { run, waitUntilScheduled, getBranchName, getDefaultBranch };
+module.exports = { run, waitUntilScheduled, getBranchName, getDefaultBranch, reRunJob };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,7 +23,7 @@ const mockGithub = {
 jest.mock('@actions/core', () => mockCore);
 jest.mock('@actions/github', () => mockGithub);
 
-const { run, waitUntilScheduled, getBranchName, getDefaultBranch } = require('../src/index');
+const { run, waitUntilScheduled, getBranchName, getDefaultBranch, reRunJob } = require('../src/index');
 
 function checkRun({ id, name, status = 'completed', jobId = '111' }) {
   return { id, name, status, details_url: `https://github.com/owner/repo/actions/runs/1/job/${jobId}` };
@@ -92,6 +92,34 @@ describe('waitUntilScheduled', () => {
   });
 });
 
+describe('reRunJob', () => {
+  const opts = { retries: 2, baseDelayMs: 1 };
+
+  it('retries transient errors and eventually succeeds', async () => {
+    mockOctokit.rest.actions.reRunJobForWorkflowRun
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({});
+
+    await reRunJob(mockOctokit, 'owner', 'repo', '111', opts);
+
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after exhausting retries', async () => {
+    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(new Error('boom'));
+
+    await expect(reRunJob(mockOctokit, 'owner', 'repo', '111', opts)).rejects.toThrow('boom');
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('does not retry when the job is already running', async () => {
+    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(new Error('This workflow is already running'));
+
+    await expect(reRunJob(mockOctokit, 'owner', 'repo', '111', opts)).rejects.toThrow('already running');
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('run', () => {
   beforeEach(() => {
     mockCore.getInput.mockImplementation(name => (name === 'check-names' ? 'build' : ''));
@@ -127,6 +155,50 @@ describe('run', () => {
 
     await run();
 
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledWith({
+      owner: 'owner', repo: 'repo', job_id: '111',
+    });
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledWith({
+      owner: 'owner', repo: 'repo', job_id: '222',
+    });
+  });
+
+  it('reruns every failed check when check-names is "*"', async () => {
+    mockCore.getInput.mockImplementation(name => (name === 'check-names' ? '*' : ''));
+    mockOctokit.paginate
+      .mockResolvedValueOnce([
+        checkRun({ id: 1, name: 'build', status: 'completed', jobId: '111' }),
+        { ...checkRun({ id: 2, name: 'test', jobId: '222' }), conclusion: 'failure' },
+        { ...checkRun({ id: 3, name: 'lint', jobId: '333' }), conclusion: 'success' },
+      ])
+      .mockResolvedValueOnce([{ ...checkRun({ id: 22, name: 'test', jobId: '222' }) }]);
+    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockResolvedValue({});
+    mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
+
+    await run();
+
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(1);
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledWith({
+      owner: 'owner', repo: 'repo', job_id: '222',
+    });
+    expect(mockCore.setOutput).toHaveBeenCalledWith('rerun-checks', 'test');
+  });
+
+  it('reruns every matching check run when a name has duplicates (matrix jobs)', async () => {
+    mockCore.getInput.mockImplementation(name => (name === 'check-names' ? 'build' : ''));
+    mockOctokit.paginate
+      .mockResolvedValueOnce([
+        checkRun({ id: 1, name: 'build', jobId: '111' }),
+        checkRun({ id: 2, name: 'build', jobId: '222' }),
+      ])
+      .mockResolvedValueOnce([checkRun({ id: 11, name: 'build', jobId: '111' })])
+      .mockResolvedValueOnce([checkRun({ id: 22, name: 'build', jobId: '222' })]);
+    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockResolvedValue({});
+    mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
+
+    await run();
+
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(2);
     expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledWith({
       owner: 'owner', repo: 'repo', job_id: '111',
     });
@@ -180,13 +252,18 @@ describe('run', () => {
     expect(mockCore.setFailed).not.toHaveBeenCalled();
   });
 
-  it('fails the action on unexpected errors', async () => {
+  it('fails the action on unexpected errors, after exhausting retries', async () => {
+    jest.useFakeTimers({ doNotFake: ['Date'] });
     mockOctokit.paginate.mockResolvedValue([checkRun({ id: 1, name: 'build' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(new Error('boom'));
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 
-    await run();
+    const runPromise = run();
+    await jest.advanceTimersByTimeAsync(1000 + 2000 + 4000 + 100);
+    await runPromise;
 
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(4);
     expect(mockCore.setFailed).toHaveBeenCalledWith('boom');
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

**Correctness/robustness**
- \`reRunJobForWorkflowRun\` now retries transient failures with exponential backoff (3 retries, 1s/2s/4s) instead of failing immediately. \"Already running\" still short-circuits without retrying.
- Fixed a latent bug for matrix jobs: \`waitUntilScheduled\`'s name-only lookup could match an unrelated sibling check run sharing the same name and report \"scheduled\" immediately without confirming anything. Now matches by check run id.

**Features**
- \`check-names: '*'\` reruns every check with a \`failure\` conclusion, instead of requiring every name listed explicitly.
- \`run()\` now reruns *every* matching check run for a given name (previously only the first), fixing matrix jobs that share a check name.

**Maintenance**
- Bumped \`@actions/core\` (1.10.1 -> 2.0.3) and \`@actions/github\` (5.1.1 -> 8.0.1) - stopped just short of 3.x/9.x, which dropped CommonJS support entirely (ESM-only) and can't be \`require()\`d by this repo's source/bundled dist.
- Fixed \`dependabot.yml\`: \`package-ecosystem: pnpm\` isn't (and for most of this config's history, wasn't) a real Dependabot ecosystem - switched to \`npm\` (covers \`pnpm-lock.yaml\` too) and added a \`github-actions\` entry.
- Fixed \`package.json\`'s \`bugs\`/\`homepage\`, which pointed at an unrelated repo (same copy-paste boilerplate source as the old \`ci.yaml\`).
- Documented the \`actions: write\` permission \`reRunJobForWorkflowRun\` has always required but was never listed in the README.

## Test plan
- [x] \`pnpm test\` passes locally (18 tests)