### PR TITLE
Structured JSON output, robust already-running check, expanded e2e coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
 | `rerun-checks`           | Comma-separated list of check names that were successfully rerun |
 | `not-found-checks`       | Comma-separated list of check names that were not found |
 | `already-running-checks` | Comma-separated list of check names that were already running |
+| `result`                 | JSON object summarizing the run: `{ "rerunChecks": [...], "notFoundChecks": [...], "alreadyRunningChecks": [...] }` |
 
 ## Permissions
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ outputs:
     description: 'Comma-separated list of check names that were not found'
   already-running-checks:
     description: 'Comma-separated list of check names that were already running'
+  result:
+    description: |
+      JSON object summarizing the run, for steps that want to parse it
+      instead of splitting the comma-separated outputs:
+      { "rerunChecks": [...], "notFoundChecks": [...], "alreadyRunningChecks": [...] }
 
 runs:
   using: 'node20'

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ async function run() {
           rerunChecks.push(checkName);
 
         } catch (error) {
-          if (error.message.includes('is already running')) {
+          if (isAlreadyRunningError(error)) {
             core.warning(`"${checkName}" job is already running.`);
             alreadyRunningChecks.push(checkName);
           } else {
@@ -60,9 +60,23 @@ async function run() {
     core.setOutput('rerun-checks', rerunChecks.join(', '));
     core.setOutput('not-found-checks', notFoundChecks.join(', '));
     core.setOutput('already-running-checks', alreadyRunningChecks.join(', '));
+    core.setOutput('result', JSON.stringify({
+      rerunChecks,
+      notFoundChecks,
+      alreadyRunningChecks,
+    }));
   } catch (error) {
     core.setFailed(error.message);
   }
+}
+
+// GitHub returns 403 for both "insufficient permissions" and "already
+// running" on this endpoint, with no separate error code to tell them apart
+// - status alone isn't enough, and message alone risks matching unrelated
+// errors that happen to contain similar text. Requiring both is the closest
+// we can get to a reliable check without a real distinguishing signal.
+function isAlreadyRunningError(error) {
+  return error.status === 403 && error.message.includes('is already running');
 }
 
 async function reRunJob(octokit, owner, repo, jobId, { retries = 3, baseDelayMs = 1000 } = {}) {
@@ -72,7 +86,7 @@ async function reRunJob(octokit, owner, repo, jobId, { retries = 3, baseDelayMs 
       return;
     } catch (error) {
       // Not a transient failure - the caller handles this case specially.
-      if (error.message.includes('is already running') || attempt > retries) {
+      if (isAlreadyRunningError(error) || attempt > retries) {
         throw error;
       }
       await new Promise(resolve => setTimeout(resolve, baseDelayMs * 2 ** (attempt - 1)));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,12 @@ function checkRun({ id, name, status = 'completed', jobId = '111' }) {
   return { id, name, status, details_url: `https://github.com/owner/repo/actions/runs/1/job/${jobId}` };
 }
 
+function alreadyRunningError() {
+  const error = new Error('This workflow is already running');
+  error.status = 403;
+  return error;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockGithub.context.payload = {};
@@ -113,10 +119,34 @@ describe('reRunJob', () => {
   });
 
   it('does not retry when the job is already running', async () => {
-    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(new Error('This workflow is already running'));
+    mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(alreadyRunningError());
 
     await expect(reRunJob(mockOctokit, 'owner', 'repo', '111', opts)).rejects.toThrow('already running');
     expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 403 that lacks the already-running message', async () => {
+    const error = new Error('Resource not accessible by integration');
+    error.status = 403;
+    mockOctokit.rest.actions.reRunJobForWorkflowRun
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({});
+
+    await reRunJob(mockOctokit, 'owner', 'repo', '111', opts);
+
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries an already-running-worded error that is not a 403', async () => {
+    const error = new Error('This workflow is already running');
+    error.status = 500;
+    mockOctokit.rest.actions.reRunJobForWorkflowRun
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({});
+
+    await reRunJob(mockOctokit, 'owner', 'repo', '111', opts);
+
+    expect(mockOctokit.rest.actions.reRunJobForWorkflowRun).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -141,6 +171,11 @@ describe('run', () => {
     expect(mockCore.setOutput).toHaveBeenCalledWith('rerun-checks', 'build');
     expect(mockCore.setOutput).toHaveBeenCalledWith('not-found-checks', '');
     expect(mockCore.setOutput).toHaveBeenCalledWith('already-running-checks', '');
+    expect(mockCore.setOutput).toHaveBeenCalledWith('result', JSON.stringify({
+      rerunChecks: ['build'],
+      notFoundChecks: [],
+      alreadyRunningChecks: [],
+    }));
     expect(mockCore.setFailed).not.toHaveBeenCalled();
   });
 
@@ -241,7 +276,7 @@ describe('run', () => {
   it('warns instead of failing when the job is already running', async () => {
     mockOctokit.paginate.mockResolvedValue([checkRun({ id: 1, name: 'build' })]);
     mockOctokit.rest.actions.reRunJobForWorkflowRun.mockRejectedValue(
-      new Error('This workflow is already running')
+      alreadyRunningError()
     );
     mockGithub.context.payload = { pull_request: { head: { ref: 'feature-1' } } };
 


### PR DESCRIPTION
## Summary

- Adds a \`result\` output: JSON summary of \`rerunChecks\`/\`notFoundChecks\`/\`alreadyRunningChecks\`, for steps that want to parse instead of splitting comma-separated strings.
- \`isAlreadyRunningError()\` now requires status 403 **and** the message text, not just a message substring. GitHub documents 403 generically for both \"insufficient permissions\" and \"already running\" on this endpoint with no distinguishing error code - status alone isn't reliable either. New unit tests confirm neither signal alone is treated as already-running.
- Expanded live e2e coverage (workflow_run listeners against real GitHub state, not just mocks):
  - \`e2e-rerun-wildcard.yaml\`: verifies \`check-names: '*'\` reruns both instances of a duplicate-named check (standing in for an unparameterized matrix job - the exact bug fixed in #12) and excludes a passing control check.
  - \`e2e-rerun-not-found.yaml\`: verifies a nonexistent check name is reported via \`notFoundChecks\` without failing the action.
  - Not covered live: the \"already running\" path - deterministic reproduction would need a real race, which is inherently flaky in CI. Left to unit tests.

## Test plan
- [x] \`pnpm test\` passes locally (20 tests)
- [ ] After merge: confirm the two new e2e-rerun-* workflows actually fire and pass (needs registering on master first, since \`workflow_run\` only listens for workflows already on the default branch - same constraint as before)