### PR TITLE
Update README example to @v3, sync package.json version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     if: github.event.review.state == 'approved'
     steps:
       - name: Rerun Checks
-        uses: shqear93/rerun-checks@v1
+        uses: shqear93/rerun-checks@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           check-names: 'check1, check2' # Replace with the names of the jobs you want to rerun

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rerun-checks",
-  "version": "1",
+  "version": "3.1.0",
   "description": "GitHub action to rerun specified GitHub checks",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
README's usage example still referenced @v1 despite v3 being current for over a year. Also syncs package.json's version field (was still the original "1" placeholder) to 3.1.0 for consistency with the latest release.